### PR TITLE
Add retries to gitlab-ctl reconfigure

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -72,6 +72,8 @@ class gitlab::config {
       command     => '/usr/bin/gitlab-ctl reconfigure',
       refreshonly => true,
       timeout     => 1800,
+      logoutput   => true,
+      tries       => 5,
     }
 
     if is_hash($postgresql) {


### PR DESCRIPTION
For some reason the reconfigure command will fail on my first puppet run but then resolve itself if I run the command manually after the puppet run.  Adding additional tries during the puppet run resolves the issue.
